### PR TITLE
Sign with SHA2_256 always

### DIFF
--- a/lib/ssh/key/signer.rb
+++ b/lib/ssh/key/signer.rb
@@ -55,7 +55,7 @@ module SSH; module Key; class Signer
         signature.signature = identity.ssh_do_sign(string)
       else
         # Only public signing identities come from our agent.
-        signature = SSH::Key::Signature.from_string(@agent.sign(identity, string))
+        signature = SSH::Key::Signature.from_string(@agent.sign(identity, string, 0x02))
       end
       signature.identity = identity
       signatures << signature


### PR DESCRIPTION
Currently signatures are always created with the default ssh-rsa.

Always sign with: `ssh-rsa-256`.

The string `0x02` requests this as per:

https://github.com/openssh/openssh-portable/blob/master/authfd.h#L119

In particular RHEL9 disables `ssh-rsa` along with all SHA1 signing.

Requires #8 